### PR TITLE
expose info & infoBuffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,9 @@ module.exports = function (torrent) {
   }
 
   var result = {}
-  result.infoHash = sha1(bncode.encode(torrent.info))
+  result.info = torrent.info
+  result.infoBuffer = bncode.encode(torrent.info)
+  result.infoHash = sha1(result.infoBuffer)
 
   result.name = torrent.info.name.toString()
   result.private = !!torrent.info.private


### PR DESCRIPTION
Related to #1, the metadata extension only works if there are peers that seed the info dictionary.  If I open a torrent file with parse-torrent, the info dictionary would be useful for that.

They're allocated anyway.
