### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
     "type": "git",
     "url": "git://github.com/webtorrent/parse-torrent.git"
   },
+  "engines": {
+    "node": ">= 5.0.0"
+  },
   "scripts": {
     "test": "standard && npm run test-node && npm run test-browser",
     "test-browser": "zuul -- test/basic.js",


### PR DESCRIPTION
Because of a Buffer.alloc reference, this module cannot work with with node < 5.0.0, we can set it in the package.json to make this clear for others