### PR TITLE
Cast parsed.private from a boolean to an integer before bencoding it.

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,11 +208,8 @@ function encodeTorrentFile (parsed) {
 
   torrent['url-list'] = parsed.urlList || []
 
-  if (parsed.private === true || parsed.private === false) {
-    // Cast boolean to integer 1 or 0; BitTorrent's bencoding can't encode
-    // booleans.
-    var privateAsInteger = parsed.private & 1
-    torrent['private'] = privateAsInteger
+  if (parsed.private !== undefined) {
+    torrent['private'] = Number(parsed.private)
   }
 
   if (parsed.created) {

--- a/index.js
+++ b/index.js
@@ -209,7 +209,10 @@ function encodeTorrentFile (parsed) {
   torrent['url-list'] = parsed.urlList || []
 
   if (parsed.private === true || parsed.private === false) {
-    torrent['private'] = parsed.private
+    // Cast boolean to integer 1 or 0; BitTorrent's bencoding can't encode
+    // booleans.
+    var privateAsInteger = parsed.private & 1
+    torrent['private'] = privateAsInteger
   }
 
   if (parsed.created) {


### PR DESCRIPTION
This PR fixes a bencode warning emitted in `encodeTorrentFile()` when fed
private torrents created by https://github.com/webtorrent/create-torrent.

> WARNING: Possible data corruption detected with value true: Bencoding only
> defines support for integers, value was converted to 1.

Sample code that produces the warning:

```javascript
#!/usr/bin/env node

const WebTorrent = require('webtorrent')
const parseTorrent = require('parse-torrent')
const createTorrent = require('create-torrent')

const filename = 'macho.jpg'
const opts = {
    private: true,
    name: filename,
    announceList: [[]],
}

createTorrent(`./${filename}`, opts, function (err, torrentBuf) {
    const parsedTorrent = parseTorrent(torrentBuf)

    // WARNING: Possible data corruption detected with value "true": Bencoding
    // only defines support for integers, value was converted to "1"
    parseTorrent.toTorrentFile(parsedTorrent)

    // The same warning is also emitted, implicitly, via WebTorrent.add().
    const client = new WebTorrent()
    client.add(torrentBuf, function (torrent) {
        process.exit(0)
    })
})

```

Which, when run, emits

```
WARNING: Possible data corruption detected with value "true": Bencoding only defines support for integers, value was converted to "1"
Trace
    at Function.encode.number (/mnt/fett/code/js/testing/node_modules/bencode/lib/encode.js:79:13)
    at Function.encode._encode (/mnt/fett/code/js/testing/node_modules/bencode/lib/encode.js:47:28)
    at Function.encode.dict (/mnt/fett/code/js/testing/node_modules/bencode/lib/encode.js:96:12)
    at Function.encode._encode (/mnt/fett/code/js/testing/node_modules/bencode/lib/encode.js:43:27)
    at Object.encode (/mnt/fett/code/js/testing/node_modules/bencode/lib/encode.js:13:10)
    at Function.encodeTorrentFile [as toTorrentFile] (/mnt/fett/code/js/testing/node_modules/parse-torrent/index.js:227:18)
    at Torrent._processParsedTorrent (/mnt/fett/code/js/testing/node_modules/webtorrent/lib/torrent.js:304:35)
    at Torrent._onParsedTorrent (/mnt/fett/code/js/testing/node_modules/webtorrent/lib/torrent.js:249:8)
    at /mnt/fett/code/js/testing/node_modules/webtorrent/lib/torrent.js:232:12
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
```

This PR fixes that 🙂.