### PR TITLE
Use const instead of var

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-var stdin = require('get-stdin')
-var parseTorrent = require('../')
+const stdin = require('get-stdin')
+const parseTorrent = require('../')
 
 function usage () {
   console.error('Usage: parse-torrent /path/to/torrent')
@@ -14,7 +14,7 @@ function error (err) {
   process.exit(1)
 }
 
-var arg = process.argv[2]
+const arg = process.argv[2]
 
 if (!arg) {
   console.error('Missing required argument')


### PR DESCRIPTION
Use `const` instead of `var` to conform to the [`no-var`](https://eslint.org/docs/rules/no-var) ESLint rule which is coming in a future version of [JavaScript Standard Style](https://standardjs.com). See https://github.com/standard/eslint-config-standard/pull/152.