### PR TITLE
feat: add options to remote function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -141,6 +141,16 @@ parseTorrent.remote(torrentId, (err, parsedTorrent) => {
 })
 ```
 
+If the `torrentId` is an http/https to the .torrent file, pass an object in the parameters
+to add `simple-get` params that will modify the request. For example:
+
+```js
+parseTorrent.remote(torrentId, { timeout: 60 * 1000 }, (err, parsedTorrent) => {
+  if (err) throw err
+  console.log(parsedTorrent)
+})
+```
+
 ### command line program
 
 This package also includes a command line program.

--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ parseTorrent.remote(torrentId, (err, parsedTorrent) => {
 })
 ```
 
-If the `torrentId` is an http/https to the .torrent file, pass an object in the parameters
-to add `simple-get` params that will modify the request. For example:
+If the `torrentId` is an http/https link to the .torrent file, then the request to the file
+can be modified by passing `simple-get` params. For example:
 
 ```js
 parseTorrent.remote(torrentId, { timeout: 60 * 1000 }, (err, parsedTorrent) => {

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ function parseTorrentRemote (torrentId, cb, options) {
       url: torrentId,
       timeout: 30 * 1000,
       headers: { 'user-agent': 'WebTorrent (https://webtorrent.io)' }
-    },options)
+    }, options)
     get.concat(options, (err, res, torrentBuf) => {
       if (err) return cb(new Error(`Error downloading torrent: ${err.message}`))
       parseOrThrow(torrentBuf)

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function parseTorrent (torrentId) {
   }
 }
 
-function parseTorrentRemote (torrentId, cb, options) {
+function parseTorrentRemote (torrentId, cb, opts) {
   let parsedTorrent
   if (typeof cb !== 'function') throw new Error('second argument must be a Function')
 
@@ -69,12 +69,12 @@ function parseTorrentRemote (torrentId, cb, options) {
     })
   } else if (typeof get === 'function' && /^https?:/.test(torrentId)) {
     // http, or https url to torrent file
-    options = Object.assign({
+    opts = Object.assign({
       url: torrentId,
       timeout: 30 * 1000,
       headers: { 'user-agent': 'WebTorrent (https://webtorrent.io)' }
-    }, options)
-    get.concat(options, (err, res, torrentBuf) => {
+    }, opts)
+    get.concat(opts, (err, res, torrentBuf) => {
       if (err) return cb(new Error(`Error downloading torrent: ${err.message}`))
       parseOrThrow(torrentBuf)
     })

--- a/index.js
+++ b/index.js
@@ -47,10 +47,11 @@ function parseTorrent (torrentId) {
   }
 }
 
-function parseTorrentRemote (torrentId, cb, opts) {
-  let parsedTorrent
+function parseTorrentRemote (torrentId, opts, cb) {
+  if (typeof opts === 'function') return parseTorrentRemote(torrentId, {}, opts)
   if (typeof cb !== 'function') throw new Error('second argument must be a Function')
 
+  let parsedTorrent
   try {
     parsedTorrent = parseTorrent(torrentId)
   } catch (err) {

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function parseTorrent (torrentId) {
   }
 }
 
-function parseTorrentRemote (torrentId, cb) {
+function parseTorrentRemote (torrentId, cb, options) {
   let parsedTorrent
   if (typeof cb !== 'function') throw new Error('second argument must be a Function')
 
@@ -69,11 +69,12 @@ function parseTorrentRemote (torrentId, cb) {
     })
   } else if (typeof get === 'function' && /^https?:/.test(torrentId)) {
     // http, or https url to torrent file
-    get.concat({
+    options = Object.assign({
       url: torrentId,
       timeout: 30 * 1000,
       headers: { 'user-agent': 'WebTorrent (https://webtorrent.io)' }
-    }, (err, res, torrentBuf) => {
+    },options)
+    get.concat(options, (err, res, torrentBuf) => {
       if (err) return cb(new Error(`Error downloading torrent: ${err.message}`))
       parseOrThrow(torrentBuf)
     })


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[X] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Hi, I want to use proxy when I called the remote function, but there are no options can pass, so I just add a param at the third param.  So now we can call by this:

```js
parseTorrent.remote(torrentId, (err, parsedTorrent) => {
  if (err) throw err
  console.log(parsedTorrent)
},{
  agent: xxx
})
```

**Is there anything you'd like reviewers to focus on?**
