### PR TITLE
Include ESM Import Notes for Remote Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ filesystem paths), as well as Blobs use the `parseTorrent.remote` function. It t
 a callback since these torrent types require async operations:
 
 ```js
-parseTorrent.remote(torrentId, (err, parsedTorrent) => {
+import {remote} from 'parse-torrent'
+remote(torrentId, (err, parsedTorrent) => {
   if (err) throw err
   console.log(parsedTorrent)
 })
@@ -145,7 +146,8 @@ If the `torrentId` is an http/https link to the .torrent file, then the request 
 can be modified by passing `simple-get` params. For example:
 
 ```js
-parseTorrent.remote(torrentId, { timeout: 60 * 1000 }, (err, parsedTorrent) => {
+import {remote} from 'parse-torrent'
+remote(torrentId, { timeout: 60 * 1000 }, (err, parsedTorrent) => {
   if (err) throw err
   console.log(parsedTorrent)
 })

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ filesystem paths), as well as Blobs use the `parseTorrent.remote` function. It t
 a callback since these torrent types require async operations:
 
 ```js
-import {remote} from 'parse-torrent'
+import { remote } from 'parse-torrent'
 remote(torrentId, (err, parsedTorrent) => {
   if (err) throw err
   console.log(parsedTorrent)
@@ -146,7 +146,7 @@ If the `torrentId` is an http/https link to the .torrent file, then the request 
 can be modified by passing `simple-get` params. For example:
 
 ```js
-import {remote} from 'parse-torrent'
+import { remote } from 'parse-torrent'
 remote(torrentId, { timeout: 60 * 1000 }, (err, parsedTorrent) => {
   if (err) throw err
   console.log(parsedTorrent)


### PR DESCRIPTION
I was confused until I found #121. Update Docs to mention this.

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[ ] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Add `import {remote} from 'parse-torrent'` line in the *Remote Torrents* section