### PR TITLE
Support utf-8 encoded comment field

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ async function decodeTorrentFile (torrent) {
   if (torrent['creation date']) result.created = new Date(torrent['creation date'] * 1000)
   if (torrent['created by']) result.createdBy = arr2text(torrent['created by'])
 
-  if (ArrayBuffer.isView(torrent.comment)) result.comment = arr2text(torrent.comment)
+  if (ArrayBuffer.isView(torrent['comment.utf-8'] || torrent.comment)) result.comment = arr2text(torrent['comment.utf-8'] || torrent.comment)
 
   // announce and announce-list will be missing if metadata fetched via ut_metadata
   if (Array.isArray(torrent['announce-list']) && torrent['announce-list'].length > 0) {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[] Bug fix
[X] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Add support for utf-8 encoded comment field, and the parsed comment content would not have garbled characters (see the below screenshot)

![image](https://github.com/webtorrent/parse-torrent/assets/2211648/9666bcc1-90eb-48d4-83c9-0ffa6f286a29)

The test torrent file case: [helloworld.txt.zip](https://github.com/webtorrent/parse-torrent/files/13538285/helloworld.txt.zip)

**Which issue (if any) does this pull request address?**
#177

**Is there anything you'd like reviewers to focus on?**
