### PR TITLE
fix: Greatly improve efficiency with torrents with a large number of files

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,18 +175,20 @@ async function decodeTorrentFile (torrent) {
   result.announce = Array.from(new Set(result.announce))
   result.urlList = Array.from(new Set(result.urlList))
 
+  let sum = 0
   const files = torrent.info.files || [torrent.info]
   result.files = files.map((file, i) => {
     const parts = [].concat(result.name, file['path.utf-8'] || file.path || []).map(p => ArrayBuffer.isView(p) ? arr2text(p) : p)
+    sum += file.length
     return {
       path: path.join.apply(null, [path.sep].concat(parts)).slice(1),
       name: parts[parts.length - 1],
       length: file.length,
-      offset: files.slice(0, i).reduce(sumLength, 0)
+      offset: sum - file.length
     }
   })
 
-  result.length = files.reduce(sumLength, 0)
+  result.length = sum
 
   const lastFile = result.files[result.files.length - 1]
 
@@ -241,10 +243,6 @@ function encodeTorrentFile (parsed) {
  */
 function isBlob (obj) {
   return typeof Blob !== 'undefined' && obj instanceof Blob
-}
-
-function sumLength (sum, file) {
-  return sum + file.length
 }
 
 function splitPieces (buf) {


### PR DESCRIPTION
Update the file offset algorithm from O(n*log(n)) to O(n). When generating the files property the offset for each file was generated by summing the lengths of all the files before. Instead cache the sum of the previous lengths. This is a very noticeable speed up for torrents of 100,000 files or more.

<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Made calculating file offset much more efficient by caching previous offset.

**Which issue (if any) does this pull request address?**
None

**Is there anything you'd like reviewers to focus on?**
Try and load a 150,000 file torrent and see how long it takes :)