### PR TITLE
fix: correct exports field to use main entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "node": ">=12.20.0"
   },
   "exports": {
-    "import": "./index.js"
+    ".": "./index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

The `exports` field was incorrectly using `"import"` as a top-level key, which Node.js treats as a **subpath export** (`parse-torrent/import`) rather than a condition. Consumers importing `parse-torrent` directly would not resolve to `./index.js`.

Fixed by using `"."` as the main entry point. Since the package already has `"type": "module"`, the simpler form without nested conditions is sufficient.

## Before

```json
"exports": {
  "import": "./index.js"
}
```

## After

```json
"exports": {
  ".": "./index.js"
}
```